### PR TITLE
add break statements to switch cases that fell through inadvertly

### DIFF
--- a/src/ElfImage.cpp
+++ b/src/ElfImage.cpp
@@ -229,6 +229,7 @@ static bool _create(FILE *fp, ElfImageData *data) {
          case SHT_GNU_LIBLIST:
            section = new ElfGNULibList(sectionName, shdr,
                                        &shdrs[shdr->sh_link], rawData);
+	   break;
          default:
            section = new ElfSection(sectionName, shdr, rawData);
            break;

--- a/src/ElfRelocationTable.cpp
+++ b/src/ElfRelocationTable.cpp
@@ -73,9 +73,9 @@ proc_rel(Elf_Shdr_t *shdrs,
           section_name = shstrtab + shdrs[sym->st_shndx].sh_name;
         } else {
           switch (sym->st_shndx) {
-            case SHN_ABS:    section_name = "ABS";
-            case SHN_COMMON: section_name = "COMMON";
-            default:         section_name = "<null>";
+            case SHN_ABS:    section_name = "ABS";    break;
+            case SHN_COMMON: section_name = "COMMON"; break;
+            default:         section_name = "<null>"; break;
           }
         }
         relocations.push_back(


### PR DESCRIPTION
A couple of switch cases did fall through inadvertently. Appropriate break statements were added.