### PR TITLE
Fixed issue where compilation would not occur, due to unresolved uint32_t symbol

### DIFF
--- a/include/libelf++/ElfGNULib.h
+++ b/include/libelf++/ElfGNULib.h
@@ -18,6 +18,7 @@
 #define _LIBELFXX_ELF_GNU_LIB_H_
 
 #include <string>
+#include <cstdint>
 
 namespace libelfxx {
 


### PR DESCRIPTION
This change fixes #5 